### PR TITLE
Add missing MinecraftServer import to WaterFluid.java

### DIFF
--- a/src/main/java/io/github/togar2/fluids/WaterFluid.java
+++ b/src/main/java/io/github/togar2/fluids/WaterFluid.java
@@ -10,6 +10,8 @@ import net.minestom.server.utils.Direction;
 
 import java.util.Optional;
 
+import static net.minestom.server.MinecraftServer.TICK_PER_SECOND;
+
 public class WaterFluid extends FlowableFluid {
 	
 	public WaterFluid() {

--- a/src/main/java/io/github/togar2/fluids/WaterFluid.java
+++ b/src/main/java/io/github/togar2/fluids/WaterFluid.java
@@ -7,10 +7,9 @@ import net.minestom.server.instance.block.Block;
 import net.minestom.server.item.Material;
 import net.minestom.server.sound.SoundEvent;
 import net.minestom.server.utils.Direction;
+import net.minestom.server.MinecraftServer;
 
 import java.util.Optional;
-
-import static net.minestom.server.MinecraftServer.TICK_PER_SECOND;
 
 public class WaterFluid extends FlowableFluid {
 	
@@ -41,7 +40,7 @@ public class WaterFluid extends FlowableFluid {
 	
 	@Override
 	public int getTickRate(Instance instance) {
-		return 5 * (TICK_PER_SECOND / 20);
+		return 5 * (MinecraftServer.TICK_PER_SECOND / 20);
 	}
 	
 	@Override


### PR DESCRIPTION
The static import for net.minestom.server.MinecraftServer.TICK_PER_SECOND was missing for some reason.